### PR TITLE
Update OWNERS and add Maintainers for SCITT-API-Emulator repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,4 +7,5 @@ maintainers:
   - OR13
   - SteveLasker
   - yogeshbdeshpande
+  - kaywilliams
 triage:


### PR DESCRIPTION
PR to add owners as maintainers for SCITT-API-Emulator Repo

Adding Kay is the change I've made to request the PR. We can remove Kay later if needed. 

Signed-off-by: kkarunakaran89 <109688962+kkarunakaran89@users.noreply.github.com>